### PR TITLE
fix(composable): disable caching & return error object

### DIFF
--- a/src/runtime/composables/useNewsletterSubscribe.ts
+++ b/src/runtime/composables/useNewsletterSubscribe.ts
@@ -1,10 +1,6 @@
-import { useFetch } from '#app'
-
 export async function useNewsletterSubscribe(email: string) {
-  const result = await useFetch(() => '/api/newsletter/subscribe', {
+  return await $fetch('/api/newsletter/subscribe', {
     body: { email },
     method: 'POST'
-  })
-
-  return result
+  }).catch(e => e.data);
 }


### PR DESCRIPTION
### Description

I've had two issues using `useNewsletterSubscribe`.

1. There is cache on the request so re-triggering a request with the same email only returns cache.
2. I am not able to explore the error object, so I can determine if the error is about the user being already subscribed or anything else.

### Fix

1. Use `$fetch` instead of `useFetch` to always trigger the request without using cache.
2. Catch the error exception and return the error object.